### PR TITLE
add allowList function

### DIFF
--- a/contracts/GCLX.sol
+++ b/contracts/GCLX.sol
@@ -17,7 +17,7 @@ contract GCLX is ERC721A, Ownable {
     uint256 public constant MAX_MINT_PER_ADDR = 2;
     uint256 public constant MAX_SUPPLY = 1000;
     uint256 public constant PRICE = 0.01 * 10**18; // 0.01 ETH
-    
+
     mapping(address => uint256) public allowlist;
 
     event Minted(address minter, uint256 amount);
@@ -50,31 +50,34 @@ contract GCLX is ERC721A, Ownable {
         emit Minted(msg.sender, quantity);
     }
 
-    function allowlistMint(uint256 quantity) external payable{
-        require(allowlist[msg.sender] > 0, "GCLX: Ni bu zai bai min dan li.");
-        require(status == Status.Started || status == Status.AllowListOnly, "GCLX: Hai mei kai shi.");
-        require(tx.origin == msg.sender, "GCLX: Bu yun xu he yue diao yong.");
+    function allowlistMint(uint256 quantity) external payable {
+        require(allowlist[msg.sender] > 0, "GCLX: Ni bu zai bai ming dan li.");
         require(
-            quantity <= allowlist[msg.sender],
-            "GCLX: Nin tai tan xin le."
+            status == Status.Started || status == Status.AllowListOnly,
+            "GCLX: Hai mei kai shi."
         );
+        require(tx.origin == msg.sender, "GCLX: Bu yun xu he yue diao yong.");
+        require(quantity <= allowlist[msg.sender], "GCLX: Nin tai tan xin le.");
         require(
             totalSupply() + quantity <= MAX_SUPPLY,
             "GCLX: Mei zhe me duo le."
         );
-        allowlist[msg.sender]=allowlist[msg.sender]-quantity;
+        allowlist[msg.sender] = allowlist[msg.sender] - quantity;
         _safeMint(msg.sender, quantity);
         refundIfOver(PRICE * quantity);
 
         emit Minted(msg.sender, quantity);
-   }
+    }
 
-    function seedAllowlist(address[] memory addresses, uint256[] memory numSlots) external onlyOwner{
-        require( addresses.length == numSlots.length, "GCLX: di zhi bu dui.");
+    function seedAllowlist(
+        address[] memory addresses,
+        uint256[] memory numSlots
+    ) external onlyOwner {
+        require(addresses.length == numSlots.length, "GCLX: di zhi bu dui.");
         for (uint256 i = 0; i < addresses.length; i++) {
-        allowlist[addresses[i]] = numSlots[i];
+            allowlist[addresses[i]] = numSlots[i];
         }
-   }
+    }
 
     function numberMinted(address owner) public view returns (uint256) {
         return _numberMinted(owner);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,94 +1,109 @@
-const { expect } = require('chai');
-const { ethers } = require('hardhat');
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
 
-describe('contract test', function () {
+describe("contract test", function () {
   let Token;
   let hardhatToken;
   let owner;
   let addr1;
-  const baseURI = 'ipfs://QmYdoCeWfvgZVwyEJfFM537qWnM21qoWU64ihBZx9nLcyx';
+  const baseURI = "ipfs://QmYdoCeWfvgZVwyEJfFM537qWnM21qoWU64ihBZx9nLcyx";
 
   beforeEach(async function () {
-    Token = await ethers.getContractFactory('GCLX');
+    Token = await ethers.getContractFactory("GCLX");
     [owner, addr1] = await ethers.getSigners();
 
     hardhatToken = await Token.deploy(baseURI);
     await hardhatToken.setStatus(1);
   });
 
-  it('Should set the right owner', async function () {
+  it("Should set the right owner", async function () {
     expect(await hardhatToken.owner()).to.equal(owner.address);
   });
 
-  it('baseURI is equal', async function () {
+  it("baseURI is equal", async function () {
     expect(await hardhatToken.baseURI()).to.equal(baseURI);
   });
 
-  it('mint ', async function () {
-    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
-    try{
-    await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.02') });
-    }
-    catch(e){
-      expect(e.message).to.contain("GCLX: Zui duo lia")
-    }
-   });
-
-  it('allowlistMint Test #1 - exceeded max number for this address ', async function () {
-    await hardhatToken.setStatus(3);
-    await hardhatToken.seedAllowlist([owner.address],[3])
-    try{
-      expect(await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') })).to.throw();
-    } catch(e){
-      expect(e.message).to.contain("GCLX: Nin tai tan xin le")
+  it("mint ", async function () {
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") });
+    try {
+      await hardhatToken.mint(2, { value: ethers.utils.parseEther("0.02") });
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Zui duo lia");
     }
   });
 
-  it('allowlistMint Test #2 - should work ', async function () {
+  it("allowlistMint Test #1 - exceeded max number for this address ", async function () {
     await hardhatToken.setStatus(3);
-    await hardhatToken.seedAllowlist([owner.address],[4])
-    await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') });
-  });
-
-  it('allowlistMint Test #3 - not in allowlist', async function () {
-    await hardhatToken.setStatus(3);
-    try{
-      expect(await hardhatToken.allowlistMint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
-    }
-    catch(e){
-      expect(e.message).to.contain("GCLX: Ni bu zai bai min dan li")
-    }
-  });
-
-  it('allowlistMint Test #4 - can not public mint if allowlistonly', async function () {
-    await hardhatToken.setStatus(3);
-    try{
-      expect(await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') })).to.throw();
-    }
-    catch(e){
-      expect(e.message).to.contain("GCLX: Hai mei kai shi")
+    await hardhatToken.seedAllowlist([owner.address], [3]);
+    try {
+      expect(
+        await hardhatToken.allowlistMint(4, {
+          value: ethers.utils.parseEther("0.04"),
+        })
+      ).to.throw();
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Nin tai tan xin le");
     }
   });
 
-  it('allowlistMint Test #5 - user can call both allowlistMint and mint functions if status=started', async function () {
+  it("allowlistMint Test #2 - should work ", async function () {
+    await hardhatToken.setStatus(3);
+    await hardhatToken.seedAllowlist([owner.address], [4]);
+    await hardhatToken.allowlistMint(4, {
+      value: ethers.utils.parseEther("0.04"),
+    });
+  });
+
+  it("allowlistMint Test #3 - not in allowlist", async function () {
+    await hardhatToken.setStatus(3);
+    try {
+      expect(
+        await hardhatToken.allowlistMint(2, {
+          value: ethers.utils.parseEther("0.04"),
+        })
+      ).to.throw();
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Ni bu zai bai ming dan li");
+    }
+  });
+
+  it("allowlistMint Test #4 - can not public mint if allowlistonly", async function () {
+    await hardhatToken.setStatus(3);
+    try {
+      expect(
+        await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") })
+      ).to.throw();
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Hai mei kai shi");
+    }
+  });
+
+  it("allowlistMint Test #5 - user can call both allowlistMint and mint functions if status=started", async function () {
     await hardhatToken.setStatus(1);
-    await hardhatToken.seedAllowlist([owner.address],[4])
-    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
+    await hardhatToken.seedAllowlist([owner.address], [4]);
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") });
     // max 2 per address under public mint(), the next call should fail with zuo duo lia
-    try{
-      expect(await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
-    }
-    catch(e){
-      expect(e.message).to.contain("GCLX: Zui duo lia")
+    try {
+      expect(
+        await hardhatToken.mint(2, { value: ethers.utils.parseEther("0.04") })
+      ).to.throw();
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Zui duo lia");
     }
     // the user can still call allowlistmint() as she is in the allowlist with limit of 4
-    await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') });
+    await hardhatToken.allowlistMint(4, {
+      value: ethers.utils.parseEther("0.04"),
+    });
     // the next call should fail as the user has used up her allowlist quota, and is considered removed from allowlist
-    try{
-      expect(await hardhatToken.allowlistMint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
-    }
-    catch(e){
-      expect(e.message).to.contain("GCLX: Ni bu zai bai min dan li")
+    try {
+      expect(
+        await hardhatToken.allowlistMint(2, {
+          value: ethers.utils.parseEther("0.04"),
+        })
+      ).to.throw();
+    } catch (e) {
+      expect(e.message).to.contain("GCLX: Ni bu zai bai ming dan li");
     }
   });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -25,8 +25,71 @@ describe('contract test', function () {
   });
 
   it('mint ', async function () {
-    await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.04') });
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
+    try{
     await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.02') });
+    }
+    catch(e){
+      expect(e.message).to.contain("GCLX: Zui duo lia")
+    }
+   });
+
+  it('allowlistMint Test #1 - exceeded max number for this address ', async function () {
+    await hardhatToken.setStatus(3);
+    await hardhatToken.seedAllowlist([owner.address],[3])
+    try{
+      expect(await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') })).to.throw();
+    } catch(e){
+      expect(e.message).to.contain("GCLX: Nin tai tan xin le")
+    }
+  });
+
+  it('allowlistMint Test #2 - should work ', async function () {
+    await hardhatToken.setStatus(3);
+    await hardhatToken.seedAllowlist([owner.address],[4])
+    await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') });
+  });
+
+  it('allowlistMint Test #3 - not in allowlist', async function () {
+    await hardhatToken.setStatus(3);
+    try{
+      expect(await hardhatToken.allowlistMint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
+    }
+    catch(e){
+      expect(e.message).to.contain("GCLX: Ni bu zai bai min dan li")
+    }
+  });
+
+  it('allowlistMint Test #4 - can not public mint if allowlistonly', async function () {
+    await hardhatToken.setStatus(3);
+    try{
+      expect(await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') })).to.throw();
+    }
+    catch(e){
+      expect(e.message).to.contain("GCLX: Hai mei kai shi")
+    }
+  });
+
+  it('allowlistMint Test #5 - user can call both allowlistMint and mint functions if status=started', async function () {
+    await hardhatToken.setStatus(1);
+    await hardhatToken.seedAllowlist([owner.address],[4])
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
+    // max 2 per address under public mint(), the next call should fail with zuo duo lia
+    try{
+      expect(await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
+    }
+    catch(e){
+      expect(e.message).to.contain("GCLX: Zui duo lia")
+    }
+    // the user can still call allowlistmint() as she is in the allowlist with limit of 4
+    await hardhatToken.allowlistMint(4, { value: ethers.utils.parseEther('0.04') });
+    // the next call should fail as the user has used up her allowlist quota, and is considered removed from allowlist
+    try{
+      expect(await hardhatToken.allowlistMint(2, { value: ethers.utils.parseEther('0.04') })).to.throw();
+    }
+    catch(e){
+      expect(e.message).to.contain("GCLX: Ni bu zai bai min dan li")
+    }
   });
 
   // it("mint more than 2", async function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,109 +1,109 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
 
-describe("contract test", function () {
+describe('contract test', function () {
   let Token;
   let hardhatToken;
   let owner;
   let addr1;
-  const baseURI = "ipfs://QmYdoCeWfvgZVwyEJfFM537qWnM21qoWU64ihBZx9nLcyx";
+  const baseURI = 'ipfs://QmYdoCeWfvgZVwyEJfFM537qWnM21qoWU64ihBZx9nLcyx';
 
   beforeEach(async function () {
-    Token = await ethers.getContractFactory("GCLX");
+    Token = await ethers.getContractFactory('GCLX');
     [owner, addr1] = await ethers.getSigners();
 
     hardhatToken = await Token.deploy(baseURI);
     await hardhatToken.setStatus(1);
   });
 
-  it("Should set the right owner", async function () {
+  it('Should set the right owner', async function () {
     expect(await hardhatToken.owner()).to.equal(owner.address);
   });
 
-  it("baseURI is equal", async function () {
+  it('baseURI is equal', async function () {
     expect(await hardhatToken.baseURI()).to.equal(baseURI);
   });
 
-  it("mint ", async function () {
-    await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") });
+  it('mint ', async function () {
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
     try {
-      await hardhatToken.mint(2, { value: ethers.utils.parseEther("0.02") });
+      await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.02') });
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Zui duo lia");
+      expect(e.message).to.contain('GCLX: Zui duo lia');
     }
   });
 
-  it("allowlistMint Test #1 - exceeded max number for this address ", async function () {
+  it('allowlistMint Test #1 - exceeded max number for this address ', async function () {
     await hardhatToken.setStatus(3);
     await hardhatToken.seedAllowlist([owner.address], [3]);
     try {
       expect(
         await hardhatToken.allowlistMint(4, {
-          value: ethers.utils.parseEther("0.04"),
+          value: ethers.utils.parseEther('0.04'),
         })
       ).to.throw();
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Nin tai tan xin le");
+      expect(e.message).to.contain('GCLX: Nin tai tan xin le');
     }
   });
 
-  it("allowlistMint Test #2 - should work ", async function () {
+  it('allowlistMint Test #2 - should work ', async function () {
     await hardhatToken.setStatus(3);
     await hardhatToken.seedAllowlist([owner.address], [4]);
     await hardhatToken.allowlistMint(4, {
-      value: ethers.utils.parseEther("0.04"),
+      value: ethers.utils.parseEther('0.04'),
     });
   });
 
-  it("allowlistMint Test #3 - not in allowlist", async function () {
+  it('allowlistMint Test #3 - not in allowlist', async function () {
     await hardhatToken.setStatus(3);
     try {
       expect(
         await hardhatToken.allowlistMint(2, {
-          value: ethers.utils.parseEther("0.04"),
+          value: ethers.utils.parseEther('0.04'),
         })
       ).to.throw();
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Ni bu zai bai ming dan li");
+      expect(e.message).to.contain('GCLX: Ni bu zai bai ming dan li');
     }
   });
 
-  it("allowlistMint Test #4 - can not public mint if allowlistonly", async function () {
+  it('allowlistMint Test #4 - can not public mint if allowlistonly', async function () {
     await hardhatToken.setStatus(3);
     try {
       expect(
-        await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") })
+        await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') })
       ).to.throw();
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Hai mei kai shi");
+      expect(e.message).to.contain('GCLX: Hai mei kai shi');
     }
   });
 
-  it("allowlistMint Test #5 - user can call both allowlistMint and mint functions if status=started", async function () {
+  it('allowlistMint Test #5 - user can call both allowlistMint and mint functions if status=started', async function () {
     await hardhatToken.setStatus(1);
     await hardhatToken.seedAllowlist([owner.address], [4]);
-    await hardhatToken.mint(1, { value: ethers.utils.parseEther("0.04") });
+    await hardhatToken.mint(1, { value: ethers.utils.parseEther('0.04') });
     // max 2 per address under public mint(), the next call should fail with zuo duo lia
     try {
       expect(
-        await hardhatToken.mint(2, { value: ethers.utils.parseEther("0.04") })
+        await hardhatToken.mint(2, { value: ethers.utils.parseEther('0.04') })
       ).to.throw();
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Zui duo lia");
+      expect(e.message).to.contain('GCLX: Zui duo lia');
     }
     // the user can still call allowlistmint() as she is in the allowlist with limit of 4
     await hardhatToken.allowlistMint(4, {
-      value: ethers.utils.parseEther("0.04"),
+      value: ethers.utils.parseEther('0.04'),
     });
     // the next call should fail as the user has used up her allowlist quota, and is considered removed from allowlist
     try {
       expect(
         await hardhatToken.allowlistMint(2, {
-          value: ethers.utils.parseEther("0.04"),
+          value: ethers.utils.parseEther('0.04'),
         })
       ).to.throw();
     } catch (e) {
-      expect(e.message).to.contain("GCLX: Ni bu zai bai ming dan li");
+      expect(e.message).to.contain('GCLX: Ni bu zai bai ming dan li');
     }
   });
 


### PR DESCRIPTION
- added AllowListOnly in status enum
- the allowlists users can be set with seedAllowlist function with a customized limit for each user in the list. and will be stored in a mapping
- added allowlistMint(), which can be executed when status == AllowListOnly || Started
- added 5 test cases for allowlistMint() with error code matching under different scenarios
- chai tests will show as "passed" for cases of expected errors
